### PR TITLE
Update to use new Travis badge for updated org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ZeroMQ bindings for React.
 
-[![Build Status](https://secure.travis-ci.org/reactphp/zmq.png?branch=master)](http://travis-ci.org/reactphp/zmq) [![Code Climate](https://codeclimate.com/github/reactphp/zmq/badges/gpa.svg)](https://codeclimate.com/github/reactphp/zmq)
+[![Build Status](https://secure.travis-ci.org/friends-of-reactphp/zmq.png?branch=master)](http://travis-ci.org/friends-of-reactphp/zmq)
 
 ## Install
 


### PR DESCRIPTION
We've moved this project from the @reactphp org to the @friends-of-reactphp org to emphasize this is not one of the core projects. The Composer package name will stay unchanged and the old repository location now redirects here, so this should not affect backwards compatibility. This simple PR updates the Travis badge to use the updated repository location.