### PR TITLE
Update ReactLoop dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.4.0",
         "ext-zmq": "*",
         "evenement/evenement": "^3.0 || ^2.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4"
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.5"
     },
     "require-dev": {
         "ext-pcntl": "*",

--- a/src/SocketWrapper.php
+++ b/src/SocketWrapper.php
@@ -136,7 +136,8 @@ class SocketWrapper extends EventEmitter
         }
 
         $this->emit('end', array($this));
-        $this->loop->removeStream($this->fileDescriptor);
+        $this->loop->removeReadStream($this->fileDescriptor);
+        $this->loop->removeWriteStream($this->fileDescriptor);
         $this->buffer->removeAllListeners();
         $this->removeAllListeners();
         unset($this->buffer);

--- a/tests/React/ZMQ/SocketWrapperTest.php
+++ b/tests/React/ZMQ/SocketWrapperTest.php
@@ -106,7 +106,12 @@ class SocketWrapperTest extends TestCase
 
         $loop
             ->expects($this->once())
-            ->method('removeStream')
+            ->method('removeReadStream')
+            ->with(14);
+
+        $loop
+            ->expects($this->once())
+            ->method('removeWriteStream')
             ->with(14);
 
         $socket = $this->getMockBuilder('ZMQSocket')


### PR DESCRIPTION
The PR includes event-loop dependency update and fix forward compatibility with lastest EventLoop releases and to prevent related issues. 

This is not an issue at the time of filing this PR but break tests.

Refs reactphp/event-loop#110 and reactphp/event-loop#118